### PR TITLE
✨ Pipeline step/config editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       ]
     }
   },
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/api/BuildkiteClient.ts
+++ b/src/api/BuildkiteClient.ts
@@ -271,4 +271,60 @@ export class BuildkiteClient implements BuildkiteAPI {
       throw error;
     }
   }
+
+  async getPipelineConfig(
+    orgSlug: string,
+    pipelineSlug: string,
+  ): Promise<string> {
+    try {
+      const baseUrl = await this.getBaseURL();
+      const url = getBuildkitePipelineApiUrl(baseUrl, orgSlug, pipelineSlug);
+      
+      const response = await this.fetchAPI.fetch(url);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch pipeline configuration: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      // Return the configuration field if it exists, otherwise format the entire response
+      if (data.configuration) {
+        return data.configuration;
+      }
+      return JSON.stringify(data, null, 2);
+    } catch (error) {
+      console.error('Error fetching pipeline configuration:', error);
+      throw error;
+    }
+  }
+
+  async updatePipelineConfig(
+    orgSlug: string,
+    pipelineSlug: string,
+    config: string,
+  ): Promise<void> {
+    try {
+      const baseUrl = await this.getBaseURL();
+      const url = getBuildkitePipelineApiUrl(baseUrl, orgSlug, pipelineSlug);
+      
+      const payload = {
+        configuration: config
+      };
+      
+      const response = await this.fetchAPI.fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+      
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to update pipeline configuration: ${errorText}`);
+      }
+    } catch (error) {
+      console.error('Error updating pipeline configuration:', error);
+      throw error;
+    }
+  }
 }

--- a/src/api/buildkiteApiRef.ts
+++ b/src/api/buildkiteApiRef.ts
@@ -32,6 +32,15 @@ export interface BuildkiteAPI {
     buildNumber: string,
     jobId: string,
   ): Promise<JobLog>;
+  getPipelineConfig(
+    orgSlug: string,
+    pipelineSlug: string,
+  ): Promise<string>;
+  updatePipelineConfig(
+    orgSlug: string,
+    pipelineSlug: string,
+    config: string,
+  ): Promise<void>;
 }
 
 export const buildkiteAPIRef = createApiRef<BuildkiteAPI>({

--- a/src/components/PipelineConfigEditor/PipelineConfigEditor.tsx
+++ b/src/components/PipelineConfigEditor/PipelineConfigEditor.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  makeStyles,
+  Snackbar,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import CloseIcon from '@material-ui/icons/Close';
+import EditIcon from '@material-ui/icons/Edit';
+import { useBuildkiteApi, usePipelineConfig } from '../../hooks/useBuildkiteApi';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    position: 'relative',
+  },
+  editorContainer: {
+    width: '100%',
+    minHeight: '60vh',
+  },
+  editor: {
+    fontFamily: 'monospace',
+    width: '100%',
+    minHeight: '60vh',
+  },
+  loadingOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(255, 255, 255, 0.7)',
+    zIndex: 1,
+  },
+  buttonWrapper: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(2),
+  },
+  editButton: {
+    marginLeft: theme.spacing(1),
+  },
+  title: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+}));
+
+type PipelineConfigEditorProps = {
+  orgSlug: string;
+  pipelineSlug: string;
+};
+
+export const PipelineConfigEditor: React.FC<PipelineConfigEditorProps> = ({
+  orgSlug,
+  pipelineSlug,
+}) => {
+  const classes = useStyles();
+  const api = useBuildkiteApi();
+  const [open, setOpen] = useState(false);
+  const [config, setConfig] = useState('');
+  const [originalConfig, setOriginalConfig] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const handleOpen = async () => {
+    setOpen(true);
+    setLoading(true);
+    setError(null);
+    try {
+      const pipelineConfig = await api.getPipelineConfig(orgSlug, pipelineSlug);
+      setConfig(pipelineConfig);
+      setOriginalConfig(pipelineConfig);
+    } catch (err) {
+      setError(`Failed to load pipeline configuration: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setConfig('');
+    setOriginalConfig('');
+    setError(null);
+  };
+
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await api.updatePipelineConfig(orgSlug, pipelineSlug, config);
+      setSuccess('Pipeline configuration updated successfully!');
+      setOriginalConfig(config);
+      setOpen(false);
+    } catch (err) {
+      setError(`Failed to update pipeline configuration: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setConfig(event.target.value);
+  };
+
+  const isConfigModified = config !== originalConfig;
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.buttonWrapper}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={handleOpen}
+          startIcon={<EditIcon />}
+          className={classes.editButton}
+        >
+          Edit Pipeline Configuration
+        </Button>
+      </div>
+
+      <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md">
+        <DialogTitle>
+          <div className={classes.title}>
+            <Typography variant="h6">
+              Edit Pipeline Configuration
+            </Typography>
+            <IconButton aria-label="close" onClick={handleClose}>
+              <CloseIcon />
+            </IconButton>
+          </div>
+        </DialogTitle>
+        <DialogContent dividers>
+          {loading && (
+            <div className={classes.loadingOverlay}>
+              <CircularProgress />
+            </div>
+          )}
+          {error && <Alert severity="error" style={{ marginBottom: '16px' }}>{error}</Alert>}
+          <div className={classes.editorContainer}>
+            <TextField
+              label="Pipeline Configuration (YAML)"
+              value={config}
+              onChange={handleChange}
+              multiline
+              variant="outlined"
+              fullWidth
+              className={classes.editor}
+              InputProps={{ style: { fontFamily: 'monospace' } }}
+              disabled={loading}
+              error={!!error}
+              placeholder="Loading pipeline configuration..."
+            />
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary" disabled={loading}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            color="primary"
+            variant="contained"
+            disabled={loading || !isConfigModified}
+          >
+            Save Changes
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={!!success}
+        autoHideDuration={6000}
+        onClose={() => setSuccess(null)}
+      >
+        <Alert onClose={() => setSuccess(null)} severity="success">
+          {success}
+        </Alert>
+      </Snackbar>
+    </div>
+  );
+};

--- a/src/components/PipelineConfigEditor/index.ts
+++ b/src/components/PipelineConfigEditor/index.ts
@@ -1,0 +1,1 @@
+export { PipelineConfigEditor } from './PipelineConfigEditor';

--- a/src/components/PipelineView/PipelineView.tsx
+++ b/src/components/PipelineView/PipelineView.tsx
@@ -12,6 +12,7 @@ import {
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import { PipelineParams, BuildParams, Navatar, BuildRow } from '..';
+import { PipelineConfigEditor } from '../PipelineConfigEditor';
 import { PipelineFilters } from '../Filters';
 
 const useStyles = makeStyles(theme => ({
@@ -280,6 +281,11 @@ export const PipelineView: React.FC<PipelineViewProps> = ({ pipeline }) => {
           </Typography>
         </Box>
       </Breadcrumbs>
+
+      <PipelineConfigEditor 
+        orgSlug={pipeline.orgSlug} 
+        pipelineSlug={pipeline.slug} 
+      />
 
       <Grid container spacing={3} direction="column">
         <Grid item>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -15,6 +15,7 @@ export { PipelinePage } from './PipelinePage';
 export { Job } from './Job';
 export { JobLogViewer } from './JobLogViewer';
 export { ViewerFetch } from './ViewerFetch';
+export { PipelineConfigEditor } from './PipelineConfigEditor';
 
 // Filter Components
 export * from './Filters';

--- a/src/hooks/useBuildkiteApi.ts
+++ b/src/hooks/useBuildkiteApi.ts
@@ -1,9 +1,13 @@
 import { useApi } from '@backstage/core-plugin-api';
 import { useAsync } from 'react-use';
-import { buildkiteAPIRef } from '../api';
+import { buildkiteAPIRef, BuildkiteAPI } from '../api';
 import { PipelineParams } from '../components';
 
-export const useBuildkiteApi = (orgSlug: string, pipelineSlug: string) => {
+export const useBuildkiteApi = () => {
+  return useApi(buildkiteAPIRef);
+};
+
+export const useBuildkitePipeline = (orgSlug: string, pipelineSlug: string) => {
   const api = useApi(buildkiteAPIRef);
 
   const {
@@ -63,6 +67,36 @@ export const useBuildkiteBuild = (
     pipeline: value?.pipeline || null,
     build: value?.build || null,
     steps: value?.steps || [],
+    loading,
+    error,
+  };
+};
+
+export const usePipelineConfig = (
+  orgSlug: string,
+  pipelineSlug: string,
+) => {
+  const api = useApi(buildkiteAPIRef);
+
+  const { 
+    value: config, 
+    loading, 
+    error 
+  } = useAsync(async () => {
+    if (!orgSlug || !pipelineSlug) {
+      return undefined;
+    }
+
+    try {
+      return await api.getPipelineConfig(orgSlug, pipelineSlug);
+    } catch (err) {
+      console.error('Error fetching pipeline config:', err);
+      throw err;
+    }
+  }, [orgSlug, pipelineSlug]);
+
+  return {
+    config,
     loading,
     error,
   };


### PR DESCRIPTION
## Changes
- Add in a `getPipelineConfig()` function to get the config of a pipeline (Client)
- Allow updating via an `updatePipelineConfig()` function (Client)
- Allow setting of YAML in the config editor similar to Buildkite UI

### How it works
- When fetching pipeline configuration, we use the main pipeline endpoint
(`/organizations/{org}/pipelines/{pipeline}`) which returns the full pipeline object including its configuration
- When updating, we send a PATCH request to the same endpoint with a payload containing the configuration field
- The configuration is displayed as YAML in the editor, as in the UI

### Testing

This can be tested by:
1. Opening a pipeline view
2. Clicking "Edit Pipeline Configuration"
3. Making changes to the YAML configuration
4. Saving the changes and verifying they appear in the Buildkite UI