### PR TITLE
chore: readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ A Buildkite plugin for Backstage that provides deep integration with your Buildk
 If the plugin is in your project's plugins directory:
 
 ```bash
-yarn workspace app add @buildkite/plugin-buildkite
+yarn workspace app add @buildkite/backstage-plugin-buildkite
 ```
 
 If you're installing from an external package:
 
 ```bash
-yarn workspace app add @buildkite/plugin-buildkite
+yarn workspace app add @buildkite/backstage-plugin-buildkite
 ```
 
 ### Configuration
@@ -83,7 +83,7 @@ buildkite:
 
 ```typescript
 // Import plugins that you want to be included in your app
-export { buildkitePlugin } from '@buildkite/plugin-buildkite';
+export { buildkitePlugin } from '@buildkite/backstage-plugin-buildkite';
 ```
 
 3. Make sure to import the plugins file in your `packages/app/src/App.tsx`:
@@ -96,7 +96,7 @@ import './plugins';
 4. Add the API factory in `packages/app/src/apis.ts`:
 
 ```typescript
-import { buildkiteAPIRef, BuildkiteClient } from '@buildkite/plugin-buildkite';
+import { buildkiteAPIRef, BuildkiteClient } from '@buildkite/backstage-plugin-buildkite';
 
 export const apis: AnyApiFactory[] = [
   createApiFactory({
@@ -121,7 +121,7 @@ export const apis: AnyApiFactory[] = [
 5. Add routes in `packages/app/src/App.tsx`:
 
 ```typescript
-import { PipelinePage } from '@buildkite/plugin-buildkite';
+import { PipelinePage } from '@buildkite/backstage-plugin-buildkite';
 
 const routes = (
   <FlatRoutes>
@@ -129,7 +129,6 @@ const routes = (
 
     {/* Buildkite Plugin Routes */}
     <Route path="/buildkite" element={<PipelinePage />} />
-    <Route path="/buildkite/build/:pipelineSlug/:buildNumber" element={<BuildPage />} />
     <Route path="/buildkite/pipeline/:orgSlug/:pipelineSlug" element={<PipelinePage />} />
   </FlatRoutes>
 );
@@ -138,7 +137,7 @@ const routes = (
 6. Add to your Entity Page in `packages/app/src/components/catalog/EntityPage.tsx`:
 
 ```typescript
-import { isBuildkiteAvailable, BuildkiteWrapper } from '@buildkite/plugin-buildkite';
+import { isBuildkiteAvailable, BuildkiteWrapper } from '@buildkite/backstage-plugin-buildkite';
 
 const cicdContent = (
   <EntitySwitch>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@buildkite/plugin-buildkite",
+  "name": "@buildkite/backstage-plugin-buildkite",
   "exports": {
     ".": "./src/index.ts",
     "./components": "./src/components/index.ts",
@@ -15,7 +15,7 @@
       ]
     }
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     "role": "frontend-plugin",
     "pluginId": "buildkite",
     "pluginPackages": [
-      "@buildkite/plugin-buildkite"
+      "@buildkite/backstage-plugin-buildkite"
     ]
   },
   "sideEffects": false,


### PR DESCRIPTION
## Changes

- README mentions `/build:` route, that doesn't exist
- update version
