### PR TITLE
Adjust parsing, add more tests

### DIFF
--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -97,6 +97,26 @@ describe('getBuildkiteApiBaseUrl', () => {
     const url = getBuildkiteApiBaseUrl('http://localhost:7000/proxy?param=value');
     expect(url).toBe('http://localhost:7000/proxy?param=value/buildkite/api');
   });
+  
+  it('handles URLs that already end with /buildkite/api', () => {
+    const url = getBuildkiteApiBaseUrl('http://localhost:7000/proxy/buildkite/api');
+    expect(url).toBe('http://localhost:7000/proxy/buildkite/api');
+  });
+  
+  it('handles URLs with /api/proxy pattern', () => {
+    const url = getBuildkiteApiBaseUrl('http://localhost:7000/api/proxy');
+    expect(url).toBe('http://localhost:7000/api/proxy/buildkite/api');
+  });
+  
+  it('handles URLs with /idp/api/proxy pattern', () => {
+    const url = getBuildkiteApiBaseUrl('https://internal-host/idp/api/proxy');
+    expect(url).toBe('https://internal-host/idp/api/proxy/buildkite/api');
+  });
+  
+  it('handles complex URLs with /api/proxy in the middle', () => {
+    const url = getBuildkiteApiBaseUrl('https://internal-host/idp/api/proxy/extra/path');
+    expect(url).toBe('https://internal-host/idp/api/proxy/buildkite/api');
+  });
 });
 
 describe('getBuildkitePipelineApiUrl', () => {

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -63,15 +63,22 @@ export function getBuildkiteApiBaseUrl(proxyPath: string): string {
     ? proxyPath.slice(0, -1) 
     : proxyPath;
     
-  // Construct the API URL to match the proxy configuration
-  // The proxy config typically has a pathRewrite like '^/api/proxy/buildkite/api' : ''
-  // So we need to ensure our URL matches this pattern
-  // 
-  // The proxy configuration expects the URL to be in the format:
-  // /api/proxy/buildkite/api/<endpoint>
-  // And it will rewrite this to:
-  // <target>/<endpoint>
-  // Where <target> is the base URL specified in the proxy config (e.g., https://api.buildkite.com/v2)
+  // Check if the path already ends with /buildkite/api
+  if (cleanProxyPath.endsWith('/buildkite/api')) {
+    return cleanProxyPath;
+  }
+  
+  // Check if the path contains /api/proxy or similar pattern
+  // This handles both /api/proxy and /idp/api/proxy cases
+  if (cleanProxyPath.includes('/api/proxy')) {
+    // Extract the base part up to and including /api/proxy
+    const basePart = cleanProxyPath.match(/(.+\/api\/proxy)/);
+    if (basePart && basePart[1]) {
+      return `${basePart[1]}/buildkite/api`;
+    }
+  }
+  
+  // Default fallback to the original behavior
   return `${cleanProxyPath}/buildkite/api`;
 }
 


### PR DESCRIPTION
## Changes

- Our initial efforts in https://github.com/buildkite/backstage-plugin/pulls/66 were futile
- We've added a check to get the internals of the path used, which should help where
    - It's now able to assess the internals of the proxy URL, rather than just assuming they start with `/api/`

Fixes: https://github.com/buildkite/backstage-plugin/issues/65
