### PR TITLE
Refactor headers to send a custom user agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
       ]
     }
   },
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {

--- a/src/api/BuildkiteClient.test.ts
+++ b/src/api/BuildkiteClient.test.ts
@@ -2,7 +2,6 @@ import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { BuildkiteClient } from './BuildkiteClient';
 import { BuildkitePluginConfig } from '../plugin';
 import { BuildkiteApiBuild, BuildkiteApiPipeline } from './types';
-import { VERSION } from '../version';
 
 describe('BuildkiteClient', () => {
   // Mock console methods to prevent test output pollution
@@ -66,6 +65,7 @@ describe('BuildkiteClient', () => {
           method: 'GET',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
+            'User-Agent': 'buildkite backstage plugin',
           }),
         }),
       );
@@ -257,8 +257,7 @@ describe('BuildkiteClient', () => {
         `http://backstage/api/proxy/buildkite/api/organizations/${orgSlug}/pipelines/${pipelineSlug}/builds/${buildNumber}/jobs/${jobId}/log`,
         expect.objectContaining({
           headers: expect.objectContaining({
-            'X-Buildkite-Plugin-Version': VERSION,
-            'X-Buildkite-Source': 'backstage-plugin',
+            'User-Agent': 'buildkite backstage plugin',
           }),
         }),
       );

--- a/src/api/BuildkiteClient.test.ts
+++ b/src/api/BuildkiteClient.test.ts
@@ -66,7 +66,7 @@ describe('BuildkiteClient', () => {
           method: 'GET',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            'User-Agent': `buildkite backstage plugin/${VERSION}`,
+            'User-Agent': `buildkite-backstage-plugin/${VERSION}`,
           }),
         }),
       );
@@ -258,7 +258,7 @@ describe('BuildkiteClient', () => {
         `http://backstage/api/proxy/buildkite/api/organizations/${orgSlug}/pipelines/${pipelineSlug}/builds/${buildNumber}/jobs/${jobId}/log`,
         expect.objectContaining({
           headers: expect.objectContaining({
-            'User-Agent': `buildkite backstage plugin/${VERSION}`,
+            'User-Agent': `buildkite-backstage-plugin/${VERSION}`,
           }),
         }),
       );

--- a/src/api/BuildkiteClient.test.ts
+++ b/src/api/BuildkiteClient.test.ts
@@ -2,6 +2,7 @@ import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { BuildkiteClient } from './BuildkiteClient';
 import { BuildkitePluginConfig } from '../plugin';
 import { BuildkiteApiBuild, BuildkiteApiPipeline } from './types';
+import { VERSION } from '../version';
 
 describe('BuildkiteClient', () => {
   // Mock console methods to prevent test output pollution
@@ -65,7 +66,7 @@ describe('BuildkiteClient', () => {
           method: 'GET',
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
-            'User-Agent': 'buildkite backstage plugin',
+            'User-Agent': `buildkite backstage plugin/${VERSION}`,
           }),
         }),
       );
@@ -257,7 +258,7 @@ describe('BuildkiteClient', () => {
         `http://backstage/api/proxy/buildkite/api/organizations/${orgSlug}/pipelines/${pipelineSlug}/builds/${buildNumber}/jobs/${jobId}/log`,
         expect.objectContaining({
           headers: expect.objectContaining({
-            'User-Agent': 'buildkite backstage plugin',
+            'User-Agent': `buildkite backstage plugin/${VERSION}`,
           }),
         }),
       );

--- a/src/api/BuildkiteClient.ts
+++ b/src/api/BuildkiteClient.ts
@@ -7,6 +7,7 @@ import {
 } from '../components';
 import { BuildkiteAPI, User } from './buildkiteApiRef';
 import { BuildkitePluginConfig } from '../plugin';
+import { VERSION } from '../version';
 import {
   BuildkiteApiBuild,
   BuildkiteApiJob,
@@ -254,7 +255,7 @@ export class BuildkiteClient implements BuildkiteAPI {
 
   private getCommonHeaders(contentType?: boolean): Record<string, string> {
     const headers: Record<string, string> = {
-      'User-Agent': 'buildkite backstage plugin',
+      'User-Agent': `buildkite backstage plugin/${VERSION}`,
     };
 
     if (contentType) {

--- a/src/api/BuildkiteClient.ts
+++ b/src/api/BuildkiteClient.ts
@@ -255,7 +255,7 @@ export class BuildkiteClient implements BuildkiteAPI {
 
   private getCommonHeaders(contentType?: boolean): Record<string, string> {
     const headers: Record<string, string> = {
-      'User-Agent': `buildkite backstage plugin/${VERSION}`,
+      'User-Agent': `buildkite-backstage-plugin/${VERSION}`,
     };
 
     if (contentType) {

--- a/src/api/BuildkiteClient.ts
+++ b/src/api/BuildkiteClient.ts
@@ -7,7 +7,6 @@ import {
 } from '../components';
 import { BuildkiteAPI, User } from './buildkiteApiRef';
 import { BuildkitePluginConfig } from '../plugin';
-import { VERSION } from '../version';
 import {
   BuildkiteApiBuild,
   BuildkiteApiJob,
@@ -255,8 +254,7 @@ export class BuildkiteClient implements BuildkiteAPI {
 
   private getCommonHeaders(contentType?: boolean): Record<string, string> {
     const headers: Record<string, string> = {
-      'X-Buildkite-Source': 'backstage-plugin',
-      'X-Buildkite-Plugin-Version': VERSION,
+      'User-Agent': 'buildkite backstage plugin',
     };
 
     if (contentType) {

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
  * Version number of the Buildkite plugin.
  * This should match the version in package.json
  */
-export const VERSION = '0.6.1';
+export const VERSION = '0.6.2';


### PR DESCRIPTION
It turns out that we can't capture most of the request headers in Datadog, so the previous solution isn't going to serve our purposes. Refactored to use a custom user agent, since we can see that in DD.