### PR TITLE
chore: remove myself from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @mcncl @buildkite/support
+* @buildkite/support

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildkite/backstage-plugin-buildkite",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A Backstage plugin which integrates with Buildkite pipelines",
   "backstage": {
     "role": "frontend-plugin",


### PR DESCRIPTION
## Description

I get notified twice if a PR is opened because I'm both _in_ the team that owns this and also a code owner myself.

This also includes the latest version bump.
